### PR TITLE
Fixes default.py

### DIFF
--- a/default.py
+++ b/default.py
@@ -1,6 +1,7 @@
 #Qlock screensaver add-on by phil65
 #credits to donabi & amet
 
+import os
 import sys
 import xbmcaddon
 


### PR DESCRIPTION
Under XBMCbuntu (at least), the script would throw a 'name os is not defined' error.
Importing os fixes this