### PR TITLE
New feature: Allow background color or image slideshows

### DIFF
--- a/resources/skins/default/720p/script-python-qlock.xml
+++ b/resources/skins/default/720p/script-python-qlock.xml
@@ -11,6 +11,28 @@
 				<effect type="fade" start="100" end="0" time="500"/>
 				<effect type="zoom" start="100" end="0" time="500" center="640,263" tween="back" easing="in"/>
 			</animation>
+			<control type="multiimage">
+				<posx>0</posx>
+				<posy>0</posy>
+				<width>1920</width>
+				<height>1080</height>
+				<aspectratio align="center">scale</aspectratio>
+				<imagepath>special://home/userdata/addon_data/qlock.backgrounds</imagepath>
+				<timeperimage>10000</timeperimage>
+				<fadetime>700</fadetime>
+				<pauseatend>0</pauseatend>
+				<randomize>true</randomize>
+				<loop>yes</loop>
+				<animation type="visible">
+				<effect type="fade" start="0" end="100" time="250" tween="sine" easing="in" />
+				<effect type="zoom" start="103" end="100" time="250" tween="cubic"center="auto" easing="in" />
+				</animation>
+				<animation type="hidden">
+				<effect type="fade" start="100" end="0" time="250" tween="sine" easing="in" />
+				<effect type="zoom" start="100" end="103" time="250" tween="cubic"center="auto" easing="out" />
+				</animation>
+				<visible></visible>
+			</control>	
 			<control type="group">
 				<posx>15</posx>
 				<posy>20</posy>


### PR DESCRIPTION
1. Create a folder "qlock.backgrounds" in userdata/addon_data
2. Add one or more images into this new folder

If you add just one image, this will be used as the background image for
the qlock screensaver. The QLock itself will then appear as a
transparent overlay over the image. This can also be used to set the
background color of QLock: just put a small (1x1 or so) PNG file with
the desired background color into the folder.
If you add multiple images, QLock will play them as a slideshow,
changing once per minute (timeperimage is set to 10000, which would mean
10 seconds - however kodi does read it as every 60 seconds...don't ask
me why)