### PR TITLE
New feature: background image/slideshow

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -1,0 +1,33 @@
+# Kodi Media Center language file
+# Addon Name: Qlock Screensaver
+# Addon id: screensaver.qlock
+# Addon Provider: Team-Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30000"
+msgid "Source of slideshow images"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Folder"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Image Folder"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Basic"
+msgstr ""

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -2,7 +2,6 @@ import sys
 import xbmc
 import xbmcgui
 
-
 __addon__ = sys.modules["__main__"].__addon__
 __addonid__ = sys.modules["__main__"].__addonid__
 __cwd__ = sys.modules["__main__"].__cwd__
@@ -22,12 +21,31 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         self.Monitor = MyMonitor(action=self.exit)
 
     def onInit(self):
+        # get addon settings
+        self.winid   = xbmcgui.Window(xbmcgui.getCurrentWindowDialogId())
+        self._get_settings()
+        self._set_prop('path', self.slideshow_path)
+        log('qlock image path: %s' % self.slideshow_path)
+
         while (not xbmc.abortRequested) and (not self.stop):
             xbmc.sleep(1000)
 
     def exit(self):
         self.stop = True
+        # clear our properties on exit
+        self._clear_prop('path')
         self.close()
+
+    def _get_settings(self):
+        # read addon settings
+        self.slideshow_path   = __addon__.getSetting('path')
+
+    def _set_prop(self, name, value):
+        self.winid.setProperty('Qlock.%s' % name, value)
+
+    def _clear_prop(self, name):
+        self.winid.clearProperty('Qlock.%s' % name)
+
 
 
 class MyMonitor(xbmc.Monitor):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <category label="30024">
+		<setting label="30001" type="folder" source="pictures" id="path"  />		
+    </category>
+</settings>

--- a/resources/skins/default/720p/script-python-qlock.xml
+++ b/resources/skins/default/720p/script-python-qlock.xml
@@ -16,21 +16,13 @@
 				<posy>0</posy>
 				<width>1920</width>
 				<height>1080</height>
-				<aspectratio align="center">scale</aspectratio>
-				<imagepath>special://home/userdata/addon_data/qlock.backgrounds</imagepath>
-				<timeperimage>10000</timeperimage>
-				<fadetime>700</fadetime>
+				<aspectratio>scale</aspectratio>
+				<imagepath>$INFO[Window.Property(Qlock.path)]</imagepath>
+				<timeperimage>60000</timeperimage>
+				<fadetime>1000</fadetime>
 				<pauseatend>0</pauseatend>
 				<randomize>true</randomize>
 				<loop>yes</loop>
-				<animation type="visible">
-				<effect type="fade" start="0" end="100" time="250" tween="sine" easing="in" />
-				<effect type="zoom" start="103" end="100" time="250" tween="cubic"center="auto" easing="in" />
-				</animation>
-				<animation type="hidden">
-				<effect type="fade" start="100" end="0" time="250" tween="sine" easing="in" />
-				<effect type="zoom" start="100" end="103" time="250" tween="cubic"center="auto" easing="out" />
-				</animation>
 				<visible></visible>
 			</control>	
 			<control type="group">

--- a/resources/skins/default/720p/script-python-qlock.xml
+++ b/resources/skins/default/720p/script-python-qlock.xml
@@ -11,6 +11,28 @@
 				<effect type="fade" start="100" end="0" time="500"/>
 				<effect type="zoom" start="100" end="0" time="500" center="640,263" tween="back" easing="in"/>
 			</animation>
+			<control type="multiimage">
+				<posx>0</posx>
+				<posy>0</posy>
+				<width>1920</width>
+				<height>1080</height>
+				<aspectratio align="center">scale</aspectratio>
+				<imagepath>special://home/userdata/addon_data/qlock.backgrounds</imagepath>
+				<timeperimage>10000</timeperimage>
+				<fadetime>700</fadetime>
+				<pauseatend>0</pauseatend>
+				<randomize>true</randomize>
+				<loop>yes</loop>
+				<animation type="visible">
+				<effect type="fade" start="0" end="100" time="250" tween="sine" easing="in" />
+				<effect type="zoom" start="103" end="100" time="250" tween="cubic"center="auto" easing="in" />
+				</animation>
+				<animation type="hidden">
+				<effect type="fade" start="100" end="0" time="250" tween="sine" easing="in" />
+				<effect type="zoom" start="100" end="103" time="250" tween="cubic"center="auto" easing="out" />
+				</animation>
+				<visible></visible>
+			</control>	
 			<control type="group">
 				<posx>15</posx>
 				<posy>20</posy>


### PR DESCRIPTION
Use the new "folder" setting of the qlock screensaver add-on if you want to use it with background images.
If your folder contains just one image, this will be used as the background image for the qlock screensaver. The QLock itself will then appear as a transparent overlay over the image. This can also be used to set the background color of QLock: just put a small (1x1 or so) PNG file with
the desired background color into the folder.
If you add multiple images, QLock will play them as a slideshow, changing once per minute.
